### PR TITLE
Catch publisher write exception in timer

### DIFF
--- a/src/Main/RSSDP.Portable/SsdpDevicePublisherBase.cs
+++ b/src/Main/RSSDP.Portable/SsdpDevicePublisherBase.cs
@@ -453,6 +453,11 @@ USN: {1}
 					SendAliveNotifications(device, true);
 				}
 			}
+            catch (ObjectDisposedException ex)
+            {
+                WriteTrace("Publisher stopped, exception " + ex.Message);
+                Dispose();
+            }
 			finally
 			{
 				if (!this.IsDisposed)


### PR DESCRIPTION
If an IP address cannot be written to (e.g. NIC disabled or reassigned) dispose timer instead of throwing exception.  Exception from System.Threading.Timer closes application, whereas just disposing the timer allows RSSDP to continue to publish on other NICs.