### PR TITLE
Don't set ExclusiveAddressUse to false on non-Windows platforms

### DIFF
--- a/src/Main/Shared/SystemNetSockets/SocketFactory.cs
+++ b/src/Main/Shared/SystemNetSockets/SocketFactory.cs
@@ -84,7 +84,16 @@ namespace Rssdp
 
 			try
 			{
+#if NETSTANDARD1_3
+				// The ExclusiveAddressUse socket option is a Windows-specific option that, when set to "true," tells Windows not to allow another socket to use the same local address as this socket
+				// See https://github.com/dotnet/corefx/pull/11509 for more details
+				if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+				{
+					retVal.ExclusiveAddressUse = false;
+				}
+#else
 				retVal.ExclusiveAddressUse = false;
+#endif
 				retVal.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 				retVal.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, multicastTimeToLive);
 				retVal.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(IPAddress.Parse(ipAddress), _LocalIP));


### PR DESCRIPTION
Don't set ExclusiveAddressUse to false on non-Windows platforms (#33)

.NET Core 1.1.0 is probably required to allow simultaneous publish and search.