### PR TITLE
Preserve headers when processing alive and byebye notifications

### DIFF
--- a/src/Main/RSSDP.Portable/SsdpDeviceLocatorBase.cs
+++ b/src/Main/RSSDP.Portable/SsdpDeviceLocatorBase.cs
@@ -479,7 +479,8 @@ ST: {4}
 					Usn = GetFirstHeaderStringValue("USN", message),
 					NotificationType = GetFirstHeaderStringValue("NT", message),
 					CacheLifetime = CacheAgeFromHeader(message.Headers.CacheControl),
-					AsAt = DateTimeOffset.Now
+					AsAt = DateTimeOffset.Now,
+					ResponseHeaders = message.Headers
 				};
 
 				AddOrUpdateDiscoveredDevice(device);
@@ -503,7 +504,8 @@ ST: {4}
 						CacheLifetime = TimeSpan.Zero,
 						DescriptionLocation = null,
 						NotificationType = GetFirstHeaderStringValue("NT", message),
-						Usn = usn
+						Usn = usn,
+						ResponseHeaders = message.Headers
 					};
 
 					if (NotificationTypeMatchesFilter(deadDevice))


### PR DESCRIPTION
Currently, both notifications and search responses trigger DeviceAvailable and DeviceUnavailable events, which is great, but only the search responses include the headers. This can lead to unexpected results if a consuming application intends to inspect the headers when devices are discovered, by any means.