### PR TITLE
[IPV6]: Now there is only link-local address for multicast

### DIFF
--- a/src/Main/RSSDP.Portable/DeviceNetworkTypeExtensions.cs
+++ b/src/Main/RSSDP.Portable/DeviceNetworkTypeExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Rssdp.Infrastructure;
+
+namespace Rssdp
+{
+	public static class DeviceNetworkTypeExtensions
+	{
+		/// <summary>
+		/// Get multicast ip address for ipv4 or ipv6 network by <see cref="DeviceNetworkType"/>
+		/// </summary>
+		/// <param name="deviceNetworkType"></param>
+		/// <returns></returns>
+		/// <exception cref="ArgumentOutOfRangeException"></exception>
+		public static string GetMulticastIpAddress(this DeviceNetworkType deviceNetworkType)
+		{
+			string multicastIpAddress;
+
+			switch (deviceNetworkType)
+			{
+				case DeviceNetworkType.Ipv4:
+					multicastIpAddress = SsdpConstants.MulticastLocalAdminAddress;
+					break;
+
+				case DeviceNetworkType.Ipv6:
+					multicastIpAddress = SsdpConstants.MulticastLinkLocalAddressV6;
+					break;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(deviceNetworkType));
+			}
+
+			return multicastIpAddress;
+		}
+	}
+}

--- a/src/Main/RSSDP.Portable/Rssdp.Portable.csproj
+++ b/src/Main/RSSDP.Portable/Rssdp.Portable.csproj
@@ -49,6 +49,7 @@
     <Compile Include="CustomHttpHeaders.cs" />
     <Compile Include="DeviceAvailableEventArgs.cs" />
     <Compile Include="DeviceNetworkType.cs" />
+    <Compile Include="DeviceNetworkTypeExtensions.cs" />
     <Compile Include="ISsdpLogger.cs" />
     <Compile Include="NullLogger.cs" />
     <Compile Include="ServiceEventArgs.cs" />

--- a/src/Main/RSSDP.Portable/SsdpConstants.cs
+++ b/src/Main/RSSDP.Portable/SsdpConstants.cs
@@ -11,18 +11,12 @@ namespace Rssdp.Infrastructure
 	/// </summary>
 	public static class SsdpConstants
 	{
-
 		/// <summary>
-		/// Multicast IPV6 Addresses used for SSDP multicast messages. Values are FF02::C, FF05::C and FF0E::C
+		/// Multicast IPV6 Address used for SSDP multicast messages. Value is FF02::C.
 		/// </summary>
-		public static readonly List<string> MulticastAdminLocalAddressV6 = new List<string>
-		{
-			"FF02::C", //(IPv6 link-local)
-			"FF05::C", //(IPv6 site-local)
-			"FF0E::C"  //(IPv6 global)
-		};
+		public const string MulticastLinkLocalAddressV6 = "FF02::C";  //(IPv6 link-local)
 		/// <summary>
-		/// Multicast IP Address used for SSDP multicast messages. Values is 239.255.255.250.
+		/// Multicast IP Address used for SSDP multicast messages. Value is 239.255.255.250.
 		/// </summary>
 		public const string MulticastLocalAdminAddress = "239.255.255.250";
 		/// <summary>

--- a/src/Main/RSSDP.Portable/SsdpDeviceLocatorBase.cs
+++ b/src/Main/RSSDP.Portable/SsdpDeviceLocatorBase.cs
@@ -431,7 +431,9 @@ ST: {4}
 		{
 			var multicastIpAddress = _CommunicationsServer.DeviceNetworkType.GetMulticastIpAddress();
 
+			var multicastMessage = BuildDiscoverMessage(serviceType, mxValue, multicastIpAddress);
 
+			_CommunicationsServer.SendMessage(multicastMessage, new UdpEndPoint
 			{
 				IPAddress = multicastIpAddress,
 				Port = SsdpConstants.MulticastPort

--- a/src/Main/RSSDP.Portable/SsdpDeviceLocatorBase.cs
+++ b/src/Main/RSSDP.Portable/SsdpDeviceLocatorBase.cs
@@ -429,31 +429,13 @@ ST: {4}
 
 		private void BroadcastDiscoverMessage(string serviceType, TimeSpan mxValue)
 		{
-			var deviceNetworkType = _CommunicationsServer.DeviceNetworkType;
+			var multicastIpAddress = _CommunicationsServer.DeviceNetworkType.GetMulticastIpAddress();
 
-			switch (deviceNetworkType)
+
 			{
-				case DeviceNetworkType.Ipv4:
-					var broadcastMessage = BuildDiscoverMessage(serviceType, mxValue, SsdpConstants.MulticastLocalAdminAddress);
-					_CommunicationsServer.SendMessage(broadcastMessage, new UdpEndPoint
-					{
-						IPAddress = SsdpConstants.MulticastLocalAdminAddress,
-						Port = SsdpConstants.MulticastPort
-					});
-					break;
-
-				case DeviceNetworkType.Ipv6:
-					foreach (var addressV6 in SsdpConstants.MulticastAdminLocalAddressV6)
-					{
-						var multicastMessageV6 = BuildDiscoverMessage(serviceType, mxValue, addressV6);
-						_CommunicationsServer.SendMessage(multicastMessageV6, new UdpEndPoint
-						{
-							IPAddress = addressV6,
-							Port = SsdpConstants.MulticastPort
-						});
-					}
-					break;
-			}
+				IPAddress = multicastIpAddress,
+				Port = SsdpConstants.MulticastPort
+			});
 		}
 
 		private void ProcessSearchResponseMessage(HttpResponseMessage message)

--- a/src/Main/RSSDP.Portable/SsdpDevicePublisherBase.cs
+++ b/src/Main/RSSDP.Portable/SsdpDevicePublisherBase.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Rssdp.Infrastructure
@@ -673,31 +675,15 @@ USN: {1}
 
 		private void SendAliveNotification(SsdpDevice device, string notificationType, string uniqueServiceName)
 		{
-			switch (_CommsServer.DeviceNetworkType)
-			{
-				case DeviceNetworkType.Ipv4:
-					var multicastMessage = BuildAliveMessage(device, notificationType, uniqueServiceName,
-						SsdpConstants.MulticastLocalAdminAddress);
-					_CommsServer.SendMessage(multicastMessage, new UdpEndPoint
-					{
-						IPAddress = SsdpConstants.MulticastLocalAdminAddress,
-						Port = SsdpConstants.MulticastPort
-					});
-					break;
+			string multicastIpAddress = _CommsServer.DeviceNetworkType.GetMulticastIpAddress();
 
-				case DeviceNetworkType.Ipv6:
-					foreach (var addressV6 in SsdpConstants.MulticastAdminLocalAddressV6)
-					{
-						var multicastMessageV6 = BuildAliveMessage(device, notificationType, uniqueServiceName,
-							addressV6);
-						_CommsServer.SendMessage(multicastMessageV6, new UdpEndPoint
-						{
-							IPAddress = addressV6,
-							Port = SsdpConstants.MulticastPort
-						});
-					}
-					break;
-			}
+			var multicastMessage = BuildAliveMessage(device, notificationType, uniqueServiceName, multicastIpAddress);
+
+			_CommsServer.SendMessage(multicastMessage, new UdpEndPoint
+			{
+				IPAddress = multicastIpAddress,
+				Port = SsdpConstants.MulticastPort
+			});
 
 			LogDeviceEvent(String.Format("Sent alive notification NT={0}, USN={1}", notificationType, uniqueServiceName), device);
 		}
@@ -757,31 +743,15 @@ USN: {1}
 		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "byebye", Justification = "Correct value for this type of notification in SSDP.")]
 		private void SendByeByeNotification(SsdpDevice device, string notificationType, string uniqueServiceName)
 		{
-			switch (_CommsServer.DeviceNetworkType)
-			{
-				case DeviceNetworkType.Ipv4:
-					var multicastMessage = BuildByeByeMessage(notificationType, uniqueServiceName,
-						SsdpConstants.MulticastLocalAdminAddress);
-					_CommsServer.SendMessage(multicastMessage, new UdpEndPoint
-					{
-						IPAddress = SsdpConstants.MulticastLocalAdminAddress,
-						Port = SsdpConstants.MulticastPort
-					});
-					break;
+			string multicastIpAddress = _CommsServer.DeviceNetworkType.GetMulticastIpAddress();
 
-				case DeviceNetworkType.Ipv6:
-					foreach (var addressV6 in SsdpConstants.MulticastAdminLocalAddressV6)
-					{
-						var multicastMessageV6 = BuildByeByeMessage(notificationType, uniqueServiceName,
-							addressV6);
-						_CommsServer.SendMessage(multicastMessageV6, new UdpEndPoint
-						{
-							IPAddress = addressV6,
-							Port = SsdpConstants.MulticastPort
-						});
-					}
-					break;
-			}
+			var multicastMessage = BuildByeByeMessage(notificationType, uniqueServiceName, multicastIpAddress);
+
+			_CommsServer.SendMessage(multicastMessage, new UdpEndPoint
+			{
+				IPAddress = multicastIpAddress,
+				Port = SsdpConstants.MulticastPort
+			});
 
 			LogDeviceEvent(String.Format("Sent byebye notification, NT={0}, USN={1}", notificationType, uniqueServiceName), device);
 		}

--- a/src/Main/Rssdp.Net45/Rssdp.Net45.csproj
+++ b/src/Main/Rssdp.Net45/Rssdp.Net45.csproj
@@ -64,6 +64,9 @@
     <Compile Include="..\RSSDP.Portable\DeviceNetworkType.cs">
       <Link>DeviceNetworkType.cs</Link>
     </Compile>
+    <Compile Include="..\RSSDP.Portable\DeviceNetworkTypeExtensions.cs">
+      <Link>DeviceNetworkTypeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\RSSDP.Portable\DeviceUnavailableEventArgs.cs">
       <Link>DeviceUnavailableEventArgs.cs</Link>
     </Compile>

--- a/src/Main/Rssdp.NetCore/Rssdp.NetCore.csproj
+++ b/src/Main/Rssdp.NetCore/Rssdp.NetCore.csproj
@@ -57,6 +57,9 @@
     <Compile Include="..\RSSDP.Portable\DeviceNetworkType.cs">
       <Link>DeviceNetworkType.cs</Link>
     </Compile>
+    <Compile Include="..\RSSDP.Portable\DeviceNetworkTypeExtensions.cs">
+      <Link>DeviceNetworkTypeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\RSSDP.Portable\DeviceUnavailableEventArgs.cs">
       <Link>Portable\DeviceUnavailableEventArgs.cs</Link>
     </Compile>

--- a/src/Main/Shared/SystemNetSockets/SocketFactory.cs
+++ b/src/Main/Shared/SystemNetSockets/SocketFactory.cs
@@ -135,19 +135,23 @@ namespace Rssdp
 		/// <returns></returns>
 		private void SetMulticastSocketOptions(Socket retVal, int multicastTimeToLive)
 		{
+			string multicastIpAddress = _deviceNetworkType.GetMulticastIpAddress();
+			IPAddress ipAddress = IPAddress.Parse(multicastIpAddress);
+
 			switch (_deviceNetworkType)
 			{
 				case DeviceNetworkType.Ipv4:
-					var ipAddress = IPAddress.Parse(SsdpConstants.MulticastLocalAdminAddress);
 					retVal.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, multicastTimeToLive);
 					retVal.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(ipAddress));
 					break;
 
 				case DeviceNetworkType.Ipv6:
 					retVal.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive, multicastTimeToLive);
-					foreach (var ipAddressV6 in SsdpConstants.MulticastAdminLocalAddressV6)
-						retVal.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.AddMembership, new IPv6MulticastOption(IPAddress.Parse(ipAddressV6)));
+					retVal.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.AddMembership, new IPv6MulticastOption(ipAddress));
 					break;
+
+				default:
+					throw new InvalidOperationException($"{nameof(_deviceNetworkType)} is not equal to Ipv4 or Ipv6");
 			}
 		}
 

--- a/src/Main/Test.SsdpPortable/CommServerTests.cs
+++ b/src/Main/Test.SsdpPortable/CommServerTests.cs
@@ -333,7 +333,7 @@ SsdpConstants.MulticastPort,
 		}
 
 		[TestMethod]
-		public void CommsServer_SendMessageV6SendsToSsdpMulticastGroupOnUnicastSoket6()
+		public void CommsServer_SendMessageV6SendsToSsdpMulticastGroupOnUnicastSoket()
 		{
 			var socketFactory = new MockSocketFactory();
 			var server = new SsdpCommunicationsServer(socketFactory);
@@ -341,7 +341,7 @@ SsdpConstants.MulticastPort,
 			string message = "Hello Everyone!";
 			server.SendMessage(System.Text.UTF8Encoding.UTF8.GetBytes(message), new UdpEndPoint
 			{
-				IPAddress = SsdpConstants.MulticastAdminLocalAddressV6[0],
+				IPAddress = SsdpConstants.MulticastLinkLocalAddressV6,
 				Port = SsdpConstants.MulticastPort
 			});
 
@@ -349,49 +349,7 @@ SsdpConstants.MulticastPort,
 
 			var mockSocket = socketFactory.UnicastSocket as MockSocket;
 			Assert.AreEqual(message, System.Text.UTF8Encoding.UTF8.GetString(mockSocket.LastMessage));
-			Assert.AreEqual(SsdpConstants.MulticastAdminLocalAddressV6[0], mockSocket.LastSentTo.IPAddress);
-			Assert.AreEqual(SsdpConstants.MulticastPort, mockSocket.LastSentTo.Port);
-		}
-
-		[TestMethod]
-		public void CommsServer_SendMessageV6SendsToSsdpMulticastGroupOnUnicastSoket2()
-		{
-			var socketFactory = new MockSocketFactory();
-			var server = new SsdpCommunicationsServer(socketFactory);
-
-			string message = "Hello Everyone!";
-			server.SendMessage(System.Text.UTF8Encoding.UTF8.GetBytes(message), new UdpEndPoint
-			{
-				IPAddress = SsdpConstants.MulticastAdminLocalAddressV6[1],
-				Port = SsdpConstants.MulticastPort
-			});
-
-			Assert.IsNotNull(socketFactory.UnicastSocket);
-
-			var mockSocket = socketFactory.UnicastSocket as MockSocket;
-			Assert.AreEqual(message, System.Text.UTF8Encoding.UTF8.GetString(mockSocket.LastMessage));
-			Assert.AreEqual(SsdpConstants.MulticastAdminLocalAddressV6[1], mockSocket.LastSentTo.IPAddress);
-			Assert.AreEqual(SsdpConstants.MulticastPort, mockSocket.LastSentTo.Port);
-		}
-
-		[TestMethod]
-		public void CommsServer_SendMessageV6SendsToSsdpMulticastGroupOnUnicastSoket3()
-		{
-			var socketFactory = new MockSocketFactory();
-			var server = new SsdpCommunicationsServer(socketFactory);
-
-			string message = "Hello Everyone!";
-			server.SendMessage(System.Text.UTF8Encoding.UTF8.GetBytes(message), new UdpEndPoint
-			{
-				IPAddress = SsdpConstants.MulticastAdminLocalAddressV6[2],
-				Port = SsdpConstants.MulticastPort
-			});
-
-			Assert.IsNotNull(socketFactory.UnicastSocket);
-
-			var mockSocket = socketFactory.UnicastSocket as MockSocket;
-			Assert.AreEqual(message, System.Text.UTF8Encoding.UTF8.GetString(mockSocket.LastMessage));
-			Assert.AreEqual(SsdpConstants.MulticastAdminLocalAddressV6[2], mockSocket.LastSentTo.IPAddress);
+			Assert.AreEqual(SsdpConstants.MulticastLinkLocalAddressV6, mockSocket.LastSentTo.IPAddress);
 			Assert.AreEqual(SsdpConstants.MulticastPort, mockSocket.LastSentTo.Port);
 		}
 

--- a/src/Main/Test.SsdpPortable/MockCommsServer.cs
+++ b/src/Main/Test.SsdpPortable/MockCommsServer.cs
@@ -112,7 +112,7 @@ namespace Test.RssdpPortable
 		public void SendMessage(byte[] messageData, UdpEndPoint destination)
 		{
 			if (SsdpConstants.MulticastLocalAdminAddress.Equals(destination.IPAddress) ||
-			    SsdpConstants.MulticastAdminLocalAddressV6.Any(a => a.Equals(destination.IPAddress)))
+				SsdpConstants.MulticastLinkLocalAddressV6.Equals(destination.IPAddress))
 				SendMulticastMessage(messageData);
 			else
 			{


### PR DESCRIPTION
Now there is only link-local address for multicast

For the following reasons:
- ssdp announcers SHALL not use global addresses
- site-local address is deprecated [https://tools.ietf.org/html/rfc3879#section-2.5.6](rfc3879)
- I think for ssdp we can use organization-local address, but don't necessary do so, so I think we can use only the link-local address

Also, here's written, we must use the link-local address, and nothing is written about organization-local 
[http://www.upnp.org/specs/arch/UPnP-arch-AnnexAIPv6-v1.pdf](annexaipv6)

FYI,
> The scope of Organization-local addresses are within different sites inside an organization. Organization-Local Multicast packets will not cross the organization's IPv6 border router to reach the IPv6 iInternet
