### PR TITLE
[fix] catch exception in timer

### DIFF
--- a/src/Main/RSSDP.Portable/SsdpDevicePublisherBase.cs
+++ b/src/Main/RSSDP.Portable/SsdpDevicePublisherBase.cs
@@ -593,6 +593,7 @@ USN: {1}
 
 		#region Alive
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
 		private void SendAllAliveNotifications(object state)
 		{
 			try

--- a/src/Main/RSSDP.Portable/SsdpDevicePublisherBase.cs
+++ b/src/Main/RSSDP.Portable/SsdpDevicePublisherBase.cs
@@ -641,6 +641,11 @@ USN: {1}
 				_Log.LogWarning("Publisher stopped, exception " + ex.Message);
 				Dispose();
 			}
+			catch (Exception ex)
+			{
+				_Log.LogWarning("Publisher stopped, exception " + ex.Message);
+				Dispose();
+			}
 			finally
 			{
 				if (!this.IsDisposed)


### PR DESCRIPTION
Hi,

I get an unhandled exception in appdomain

```
System.Net.Sockets.SocketException (0x80004005): 
   в System.Net.Sockets.Socket.SendTo(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags, EndPoint remoteEP)
   в Rssdp.UdpSocket.SendTo(Byte[] messageData, UdpEndPoint endPoint)
   в Rssdp.Infrastructure.SsdpCommunicationsServer.<>c__DisplayClass21_0.<SendMessage>b__0()
   в Rssdp.Infrastructure.SsdpCommunicationsServer.Repeat(Int32 repetitions, TimeSpan delay, Action work)
   в Rssdp.Infrastructure.SsdpDevicePublisherBase.SendAliveNotification(SsdpDevice device, String notificationType, String uniqueServiceName)
   в Rssdp.Infrastructure.SsdpDevicePublisherBase.SendAliveNotifications(SsdpDevice device, Boolean isRoot)
   в Rssdp.Infrastructure.SsdpDevicePublisherBase.SendAllAliveNotifications(Object state)
   в System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   в System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   в System.Threading.TimerQueueTimer.CallCallback()
   в System.Threading.TimerQueueTimer.Fire()
   в System.Threading.TimerQueue.FireNextTimers()
```

And app crashes due to an unhandled exception in the threadpool

It's very easy to repeat

Create publisher on specified address:
```
var socketFactory = new SocketFactory("..");
var communicationsServer = new SsdpCommunicationsServer(socketFactory, 0);
var devicePublisher = new SsdpDevicePublisher(communicationsServer);
```

And next disable the adapter which associated with this address