### PR TITLE
Compare local name when parsing custom properties

### DIFF
--- a/src/Main/RSSDP.Portable/SsdpDevice.cs
+++ b/src/Main/RSSDP.Portable/SsdpDevice.cs
@@ -920,7 +920,7 @@ namespace Rssdp
 
 			if (reader.NodeType != XmlNodeType.CDATA && reader.NodeType != XmlNodeType.Text)
 			{
-				while (!reader.EOF && (reader.NodeType != XmlNodeType.EndElement || reader.Name != newProp.Name || reader.Prefix != newProp.Namespace || reader.Depth != depth))
+				while (!reader.EOF && (reader.NodeType != XmlNodeType.EndElement || reader.LocalName != newProp.Name || reader.Prefix != newProp.Namespace || reader.Depth != depth))
 				{
 					reader.Read();
 				}


### PR DESCRIPTION
The inner loop in AddCustomProperty compares names
and prefixes separately, so it should use the `reader.LocalName`
property when comparing. The previous version of the code
used `reader.Name` which includes the prefix.