### PR TITLE
Ensure that empty elements don't break the parser

### DIFF
--- a/src/Main/Rssdp.Shared/SsdpDevice.cs
+++ b/src/Main/Rssdp.Shared/SsdpDevice.cs
@@ -917,6 +917,14 @@ namespace Rssdp
 
 		private static void AddCustomProperty(XmlReader reader, SsdpDevice device)
 		{
+			// If the property is an empty element, there is no value to read
+			// Advance the reader and return
+			if (reader.IsEmptyElement)
+			{
+				reader.Read();
+				return;
+			}
+
 			var newProp = new SsdpDeviceProperty() { Namespace = reader.Prefix, Name = reader.LocalName };
 			int depth = reader.Depth;
 			reader.Read();

--- a/src/Main/Test.SsdpPortable/SsdpDeviceTests.cs
+++ b/src/Main/Test.SsdpPortable/SsdpDeviceTests.cs
@@ -555,7 +555,6 @@ namespace Test.RssdpPortable
 		{
 			//See issue #70 in repo - empty custom properties would cause
 			//all following properties to be skipped.
-
 			var docString = @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <root xmlns=""urn:schemas-upnp-org:device-1-0"">
   <specVersion>
@@ -567,6 +566,7 @@ namespace Test.RssdpPortable
     <UDN>uuid:55076f6e-6b79-1d65-a472-00059a3c7a00</UDN>
     <friendlyName>Twonky :)</friendlyName>
     <pv:extension xmlns:pv=""http://www.pv.com/pvns/""></pv:extension>
+    <pv:empty_extension xmlns:pv=""http://www.pv.com/pvns/"" />
     <manufacturer>PacketVideo</manufacturer>
     <manufacturerURL>http://www.pv.com</manufacturerURL>
     <modelName>TwonkyServer</modelName>


### PR DESCRIPTION
Empty elements like <example/> need special handling,
because the previous parsing code assumed that each
start element had a corresponding end element.