### PR TITLE
[fix] handle exceptions in the thread pool

### DIFF
--- a/src/Main/Rssdp.Shared/SsdpCommunicationsServer.cs
+++ b/src/Main/Rssdp.Shared/SsdpCommunicationsServer.cs
@@ -336,11 +336,7 @@ namespace Rssdp.Infrastructure
 							cancelled = true;
 							break;
 						}
-						catch (ObjectDisposedException)
-						{
-							cancelled = true;
-						}
-						catch (TaskCanceledException)
+						catch (Exception)
 						{
 							cancelled = true;
 						}
@@ -410,6 +406,7 @@ namespace Rssdp.Infrastructure
 					responseMessage = _ResponseParser.Parse(data);
 				}
 				catch (ArgumentException) { } // Ignore invalid packets.
+				catch (FormatException) { } // Ignore invalid packets.
 
 				if (responseMessage != null)
 					OnResponseReceived(responseMessage, endPoint);
@@ -422,6 +419,7 @@ namespace Rssdp.Infrastructure
 					requestMessage = _RequestParser.Parse(data);
 				}
 				catch (ArgumentException) { } // Ignore invalid packets.
+				catch (FormatException) { } // Ignore invalid packets.
 
 				if (requestMessage != null)
 					OnRequestReceived(requestMessage, endPoint);


### PR DESCRIPTION
Sometimes I get such exceptions and app crashes because they are raised in the thread pool. so I'd like to offer a way to handle these exceptions

```
Unhandled Exception  TaskScheduler.UnobservedTaskException.
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. ---> System.Net.Sockets.SocketException: An existing connection was forcibly closed by the remote host
   at System.Net.Sockets.Socket.EndReceiveFrom(IAsyncResult asyncResult, EndPoint& endPoint)
   at Rssdp.UdpSocket.ProcessResponse(AsyncReceiveState state, Func`1 receiveData)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Rssdp.Infrastructure.SsdpCommunicationsServer.<>c__DisplayClass33_0.<<ListenToSocket>b__0>d.MoveNext()
   --- End of inner exception stack trace ---
---> (Inner Exception #0) System.Net.Sockets.SocketException (0x80004005): An existing connection was forcibly closed by the remote host
   at System.Net.Sockets.Socket.EndReceiveFrom(IAsyncResult asyncResult, EndPoint& endPoint)
   at Rssdp.UdpSocket.ProcessResponse(AsyncReceiveState state, Func`1 receiveData)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Rssdp.Infrastructure.SsdpCommunicationsServer.<>c__DisplayClass33_0.<<ListenToSocket>b__0>d.MoveNext()<---
```

```
Unhandled Exception TaskScheduler.UnobservedTaskException.
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. ---> System.FormatException: The format of the HTTP method is invalid.
   at System.Net.Http.HttpMethod..ctor(String method)
   at Rssdp.Infrastructure.HttpRequestParser.ParseStatusLine(String data, HttpRequestMessage message)
   at Rssdp.Infrastructure.HttpParserBase`1.Parse(T message, HttpHeaders headers, String data)
   at Rssdp.Infrastructure.HttpRequestParser.Parse(String data)
   at Rssdp.Infrastructure.SsdpCommunicationsServer.ProcessMessage(String data, UdpEndPoint endPoint)
   at System.Threading.Tasks.Task.Execute()
   --- End of inner exception stack trace ---
---> (Inner Exception #0) System.FormatException: The format of the HTTP method is invalid.
   at System.Net.Http.HttpMethod..ctor(String method)
   at Rssdp.Infrastructure.HttpRequestParser.ParseStatusLine(String data, HttpRequestMessage message)
   at Rssdp.Infrastructure.HttpParserBase`1.Parse(T message, HttpHeaders headers, String data)
   at Rssdp.Infrastructure.HttpRequestParser.Parse(String data)
   at Rssdp.Infrastructure.SsdpCommunicationsServer.ProcessMessage(String data, UdpEndPoint endPoint)
   at System.Threading.Tasks.Task.Execute()<---
```