### PR TITLE
FIX random crash: Catch ObjectDispose exceptions on EndReceiveFrom

### DIFF
--- a/src/Main/Shared/SystemNetSockets/UdpSocket.cs
+++ b/src/Main/Shared/SystemNetSockets/UdpSocket.cs
@@ -73,9 +73,22 @@ namespace Rssdp
 			try
 			{
 				_Socket.BeginReceiveFrom(state.Buffer, 0, state.Buffer.Length, System.Net.Sockets.SocketFlags.None, ref state.EndPoint,
-					new AsyncCallback((result) => ProcessResponse(state, () => state.Socket.EndReceiveFrom(result, ref state.EndPoint))), state);
+					new AsyncCallback((result) => ProcessResponse(state,
+            () =>
+						{
+							try
+							{
+								return state.Socket.EndReceiveFrom(result, ref state.EndPoint);
+							}
+							catch (ObjectDisposedException)
+							{
+								if (!this.IsDisposed) throw;
+							} //Only rethrow disposed exceptions if we're NOT disposed, because then they are unexpected.
+							return 0;
+						}	))
+					, state);
 			}
-			catch (ObjectDisposedException) { if (!this.IsDisposed) throw; } //Only rethrow disposed exceptions if we're NOT disposed, because then they are unexpected.
+			catch (ObjectDisposedException) { if (!this.IsDisposed) throw; } 
 
 #endif
 


### PR DESCRIPTION
I've fixed a random crash on UDPSocket when running on dot net core. It would be great if you could integrate it 